### PR TITLE
Fix conflict between react-native-vlc-media-player and react-native-video

### DIFF
--- a/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
@@ -14,15 +14,15 @@ RCT_EXPORT_MODULE();
 }
 
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
-RCT_EXPORT_VIEW_PROPERTY(onVideoProgress, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoPaused, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoStopped, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoBuffering, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoPlaying, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoEnded, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoError, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoOpen, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoProgress, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoPaused, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoStopped, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoBuffering, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoPlaying, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoEnded, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoError, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoOpen, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTDirectEventBlock);
 
 - (dispatch_queue_t)methodQueue
 {


### PR DESCRIPTION
We are facing an issue due to the fact that the library react-native-video is using "RCTDirectEventBlock" for event blocking and react-native-vlc-media-player is using "RCTBubblingEventBlock" which causes conflict, setting the same blocking type for both libraries solves the problem.

https://github.com/react-native-video/react-native-video/issues/1850
