### PR TITLE
MobileVLCKit updated to 3.3.17 with support of c++14

### DIFF
--- a/react-native-vlc-media-player.podspec
+++ b/react-native-vlc-media-player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "react-native-vlc-media-player"
-  s.version      = "1.0.6"
+  s.version      = "1.0.38"
   s.summary      = "VLC player"
   s.requires_arc = true
   s.author       = { 'roshan.milinda' => 'rmilinda@gmail.com' }
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/razorRun/react-native-vlc-media-player.git" }
   s.source_files = 'ios/RCTVLCPlayer/*'
   s.platform     = :ios, "8.0"
-  s.static_framework = true  
+  s.static_framework = true
   s.dependency 'React'
-  s.dependency 'MobileVLCKit', '3.3.14'
+  s.dependency 'MobileVLCKit', '3.3.17'
 end


### PR DESCRIPTION
Fix warning: `Can't merge user_target_xcconfig for pod targets: ["MobileVLCKit", "RNReanimated"]. Singular build setting CLANG_CXX_LANGUAGE_STANDARD has different values` due RN 0.64.x moving to the c++14