### PR TITLE
replace videolan maven url

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ android {
 
 repositories {
     maven {
-        url "https://dl.bintray.com/videolan/Android"
+        url "https://mvnrepository.com/artifact/org.videolan.android"
     }
     google()
     jcenter()


### PR DESCRIPTION
**https://dl.bintray.com/videolan/Android** offen 502, so replace a stable address.
![image](https://user-images.githubusercontent.com/17498633/145545202-ac638cd2-0b06-47d3-b598-1dfa11c2a178.png)
