### PR TITLE
Feature/audiotrack and subtitle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+# Android
+#
+.gradle

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ VideoInfo example:
         {id: 5, name: "Track 2 - [Japanese]"}
     ],    
 }
+```
 
 ## More formats
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Prop | Description | Default
 `seek` | Set position to seek between `0` and `1` (`0` being the start, `1` being the end , use `position` from the progress object )
 `volume` | Set the volume of the player (`number`)
 `muted` | Set to `true` or `false` to mute the player |  `false`
+`audioTrack` | Set audioTrack id 
+`textTrack` | Set textTrack(subtitle) id
 `playInBackground` | Set to `true` or `false` to allow playing in the background | false
 `videoAspectRatio ` | Set the video aspect ratio eg `"16:9"`
 `autoAspectRatio` | Set to `true` or `false` to enable auto aspect ratio | false
@@ -133,12 +135,31 @@ Callback props take a function that gets fired on various player events:
 Prop | Description
 ---- | -----------
 `onPlaying` | Called when media starts playing returns eg `{target: 9, duration: 99750, seekable: true}`
-`onProgress` | Callback containing `position` as a fraction, and `duration`, `currentTime` and `remainingTime` in seconds <br />&nbsp; ◦ &nbsp;eg `{  duration: 99750, position: 0.30, currentTime: 30154, remainingTime: -69594 }`
+`onProgress` | Callback containing `position` as a fraction, and `duration`, `currentTime` and `remainingTime` in seconds <br />&nbsp; ◦ &nbsp;eg `{  duration: 99750, position: 0.30, currentTime: 30154, remainingTime: -69594 }
 `onPaused` | Called when media is paused
 `onStopped ` | Called when media is stoped
 `onBuffering ` | Called when media is buffering
 `onEnded` | Called when media playing ends
 `onError` | Called when an error occurs whilst attempting to play media
+`onLoad` | Called when video info is loaded, Callback containing VideoInfo
+
+VideoInfo example:
+```
+ {
+    duration: 30906, 
+    videoSize: {height: 240, width: 32},
+    audioTracks: [
+            {id: -1, name: "Disable"}, 
+            {id: 1, name: "Track 1"}, 
+            {id: 3, name: "Japanese Audio (2ch LC-AAC) - [Japanese]"}
+    ], 
+    textTracks: [
+        {id: -1, name: "Disable"}, 
+        {id: 4, name: "Track 1 - [English]"}, 
+        {id: 5, name: "Track 2 - [Japanese]"}
+    ],    
+}
+```
 
 
 ## More formats

--- a/VLCPlayer.js
+++ b/VLCPlayer.js
@@ -24,6 +24,7 @@ export default class VLCPlayer extends Component {
     this._onBuffering = this._onBuffering.bind(this);
     this._onOpen = this._onOpen.bind(this);
     this._onLoadStart = this._onLoadStart.bind(this);
+    this._onLoad = this._onLoad.bind(this);
     this.changeVideoAspectRatio = this.changeVideoAspectRatio.bind(this);
   }
   static defaultProps = {
@@ -113,6 +114,12 @@ export default class VLCPlayer extends Component {
     }
   }
 
+  _onLoad(event) {
+    if (this.props.onLoad) {
+      this.props.onLoad(event.nativeEvent);
+    }
+  }
+
   render() {
     /* const {
      source
@@ -161,6 +168,7 @@ export default class VLCPlayer extends Component {
       onVideoPaused: this._onPaused,
       onVideoStopped: this._onStopped,
       onVideoBuffering: this._onBuffering,
+      onVideoLoad: this._onLoad,
       progressUpdateInterval: 250,
     });
 
@@ -187,6 +195,8 @@ VLCPlayer.propTypes = {
   poster: PropTypes.string,
   repeat: PropTypes.bool,
   muted: PropTypes.bool,
+  audioTrack: PropTypes.number,
+  textTrack: PropTypes.number,
 
   onVideoLoadStart: PropTypes.func,
   onVideoError: PropTypes.func,
@@ -197,6 +207,7 @@ VLCPlayer.propTypes = {
   onVideoStopped: PropTypes.func,
   onVideoBuffering: PropTypes.func,
   onVideoOpen: PropTypes.func,
+  onVideoLoad: PropTypes.func,
 
   /* Wrapper component */
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
@@ -34,6 +34,8 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     private static final String PROP_AUTO_ASPECT_RATIO = "autoAspectRatio";
     private static final String PROP_CLEAR = "clear";
     private static final String PROP_PROGRESS_UPDATE_INTERVAL = "progressUpdateInterval";
+    private static final String PROP_TEXT_TRACK = "textTrack";
+    private static final String PROP_AUDIO_TRACK = "audioTrack";
 
 
     @Override
@@ -146,7 +148,15 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
         videoView.doSnapshot(snapshotPath);
     }
 
+    @ReactProp(name = PROP_AUDIO_TRACK)
+    public void setAudioTrack(final ReactVlcPlayerView videoView, final int audioTrack) {
+        videoView.setAudioTrack(audioTrack);
+    }
 
+    @ReactProp(name = PROP_TEXT_TRACK)
+    public void setTextTrack(final ReactVlcPlayerView videoView, final int textTrack) {
+        videoView.setTextTrack(textTrack);
+    }
 
     private boolean startsWithValidScheme(String uriString) {
         return uriString.startsWith("http://")

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/VideoEventEmitter.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/VideoEventEmitter.java
@@ -36,6 +36,7 @@ class VideoEventEmitter {
     public static final String EVENT_ON_ERROR = "onVideoError";
     public static final String EVENT_ON_VIDEO_BUFFERING = "onVideoBuffering";
     public static final String EVENT_ON_PAUSED = "onVideoPaused";
+    public static final String EVENT_ON_LOAD = "onVideoLoad";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -49,7 +50,8 @@ class VideoEventEmitter {
             EVENT_ON_PAUSED,
             EVENT_ON_VIDEO_BUFFERING,
             EVENT_ON_ERROR,
-            EVENT_ON_VIDEO_STOPPED
+            EVENT_ON_VIDEO_STOPPED,
+            EVENT_ON_LOAD
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -65,7 +67,8 @@ class VideoEventEmitter {
             EVENT_ON_PAUSED,
             EVENT_ON_VIDEO_BUFFERING,
             EVENT_ON_ERROR,
-            EVENT_ON_VIDEO_STOPPED
+            EVENT_ON_VIDEO_STOPPED,
+            EVENT_ON_LOAD
     })
 
     @interface VideoEvents {

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.h
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.h
@@ -13,6 +13,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoError;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoOpen;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoadStart;
+@property (nonatomic, copy) RCTBubblingEventBlock onVideoLoad;
 
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -11,6 +11,12 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
 static NSString *const readyForDisplayKeyPath = @"readyForDisplay";
 static NSString *const playbackRate = @"rate";
 
+
+#if !defined(DEBUG) || !(TARGET_IPHONE_SIMULATOR)
+    #define NSLog(...)
+#endif
+
+
 @implementation RCTVLCPlayer
 {
 
@@ -21,6 +27,8 @@ static NSString *const playbackRate = @"rate";
     NSDictionary * _source;
     BOOL _paused;
     BOOL _started;
+    
+    NSDictionary * _videoInfo;
 
 }
 
@@ -109,6 +117,7 @@ static NSString *const playbackRate = @"rate";
     options = nil;
 
     _player.media = media;
+    _player.media.delegate = self;
     [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
     NSLog(@"autoplay: %i",autoplay);
     self.onVideoLoadStart(@{
@@ -122,6 +131,8 @@ static NSString *const playbackRate = @"rate";
         [self _release];
     }
     _source = source;
+    _videoInfo = nil;
+    
     // [bavv edit start]
     NSString* uri    = [source objectForKey:@"uri"];
     BOOL    autoplay = [RCTConvert BOOL:[source objectForKey:@"autoplay"]];
@@ -144,6 +155,7 @@ static NSString *const playbackRate = @"rate";
     options = nil;
 
     _player.media = media;
+    _player.media.delegate = self;
     [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
     NSLog(@"autoplay: %i",autoplay);
     self.onVideoLoadStart(@{
@@ -152,6 +164,9 @@ static NSString *const playbackRate = @"rate";
 //    if(autoplay)
         [self play];
 }
+
+
+// ==== player delegate methods ====
 
 - (void)mediaPlayerTimeChanged:(NSNotification *)aNotification
 {
@@ -168,33 +183,39 @@ static NSString *const playbackRate = @"rate";
         VLCMediaPlayerState state = _player.state;
         switch (state) {
             case VLCMediaPlayerStateOpening:
-                 NSLog(@"VLCMediaPlayerStateOpening %i",1);
+                 NSLog(@"VLCMediaPlayerStateOpening  %i", _player.numberOfAudioTracks);
                 self.onVideoOpen(@{
                                      @"target": self.reactTag
                                      });
                 break;
             case VLCMediaPlayerStatePaused:
                 _paused = YES;
-                NSLog(@"VLCMediaPlayerStatePaused %i",1);
+                NSLog(@"VLCMediaPlayerStatePaused %i", _player.numberOfAudioTracks);
                 self.onVideoPaused(@{
                                      @"target": self.reactTag
                                      });
                 break;
             case VLCMediaPlayerStateStopped:
-                NSLog(@"VLCMediaPlayerStateStopped %i",1);
+                NSLog(@"VLCMediaPlayerStateStopped %i", _player.numberOfAudioTracks);
                 self.onVideoStopped(@{
                                       @"target": self.reactTag
                                       });
                 break;
             case VLCMediaPlayerStateBuffering:
-                NSLog(@"VLCMediaPlayerStateBuffering %i",1);
+                NSLog(@"VLCMediaPlayerStateBuffering %i", _player.numberOfAudioTracks);
+                if(!_videoInfo && _player.numberOfAudioTracks > 0) {
+                    _videoInfo = [self getVideoInfo];
+                    self.onVideoLoad(_videoInfo);
+                }
+
+                
                 self.onVideoBuffering(@{
                                         @"target": self.reactTag
                                         });
                 break;
             case VLCMediaPlayerStatePlaying:
                 _paused = NO;
-                NSLog(@"VLCMediaPlayerStatePlaying %i",1);
+                NSLog(@"VLCMediaPlayerStatePlaying %i", _player.numberOfAudioTracks);
                 self.onVideoPlaying(@{
                                       @"target": self.reactTag,
                                       @"seekable": [NSNumber numberWithBool:[_player isSeekable]],
@@ -202,7 +223,7 @@ static NSString *const playbackRate = @"rate";
                                       });
                 break;
             case VLCMediaPlayerStateEnded:
-                NSLog(@"VLCMediaPlayerStateEnded %i",1);
+                NSLog(@"VLCMediaPlayerStateEnded %i",  _player.numberOfAudioTracks);
                 int currentTime   = [[_player time] intValue];
                 int remainingTime = [[_player remainingTime] intValue];
                 int duration      = [_player.media.length intValue];
@@ -216,7 +237,7 @@ static NSString *const playbackRate = @"rate";
                                     });
                 break;
             case VLCMediaPlayerStateError:
-                NSLog(@"VLCMediaPlayerStateError %i",1);
+                NSLog(@"VLCMediaPlayerStateError %i", _player.numberOfAudioTracks);
                 self.onVideoError(@{
                                     @"target": self.reactTag
                                     });
@@ -227,6 +248,19 @@ static NSString *const playbackRate = @"rate";
         }
     }
 }
+
+
+//   ===== media delegate methods =====
+
+-(void)mediaDidFinishParsing:(VLCMedia *)aMedia {
+    NSLog(@"VLCMediaDidFinishParsing %i", _player.numberOfAudioTracks);
+}
+
+- (void)mediaMetaDataDidChange:(VLCMedia *)aMedia{
+    NSLog(@"VLCMediaMetaDataDidChange %i", _player.numberOfAudioTracks);
+}
+
+//   ===================================
 
 -(void)updateVideoProgress
 {
@@ -245,6 +279,44 @@ static NSString *const playbackRate = @"rate";
                                    });
         }
     }
+}
+
+-(NSDictionary *)getVideoInfo
+{
+    NSMutableDictionary *info = [NSMutableDictionary new];
+    info[@"duration"] = _player.media.length.value;
+    int i;
+    if(_player.videoSize.width > 0) {
+        info[@"videoSize"] =  @{
+            @"width":  @(_player.videoSize.width),
+            @"height": @(_player.videoSize.height)
+        };
+    }
+   if(_player.numberOfAudioTracks > 0) {
+        NSMutableArray *tracks = [NSMutableArray new];
+        for (i = 0; i < _player.numberOfAudioTracks; i++) {
+            if(_player.audioTrackIndexes[i] && _player.audioTrackNames[i]) {
+                [tracks addObject:  @{
+                    @"id": _player.audioTrackIndexes[i],
+                    @"name":  _player.audioTrackNames[i]
+                }];
+            }
+        }
+        info[@"audioTracks"] = tracks;
+    }
+    if(_player.numberOfSubtitlesTracks > 0) {
+        NSMutableArray *tracks = [NSMutableArray new];
+        for (i = 0; i < _player.numberOfSubtitlesTracks; i++) {
+            if(_player.videoSubTitlesIndexes[i] && _player.videoSubTitlesNames[i]) {
+                [tracks addObject:  @{
+                    @"id": _player.videoSubTitlesIndexes[i],
+                    @"name":  _player.videoSubTitlesNames[i]
+                }];
+            }
+        }
+        info[@"textTracks"] = tracks;
+    }
+    return info;
 }
 
 - (void)jumpBackward:(int)interval
@@ -278,6 +350,17 @@ static NSString *const playbackRate = @"rate";
 {
     [_player setRate:rate];
 }
+
+-(void)setAudioTrack:(int)track
+{
+    [_player setCurrentAudioTrackIndex: track];
+}
+
+-(void)setTextTrack:(int)track
+{
+    [_player setCurrentVideoSubTitleIndex:track];
+}
+
 
 -(void)setVideoAspectRatio:(NSString *)ratio{
     char *char_content = [ratio cStringUsingEncoding:NSASCIIStringEncoding];

--- a/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
@@ -23,6 +23,7 @@ RCT_EXPORT_VIEW_PROPERTY(onVideoEnded, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoError, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoOpen, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTDirectEventBlock);
 
 - (dispatch_queue_t)methodQueue
 {
@@ -41,5 +42,7 @@ RCT_CUSTOM_VIEW_PROPERTY(muted, BOOL, RCTVLCPlayer)
     BOOL isMuted = [RCTConvert BOOL:json];
     [view setMuted:isMuted];
 };
+RCT_EXPORT_VIEW_PROPERTY(audioTrack, int);
+RCT_EXPORT_VIEW_PROPERTY(textTrack, int);
 
 @end


### PR DESCRIPTION
ability to switch audio tracks and subtitles (issue #137)

added onLoad event to get information about audio tracks and subtitles
added props: audioTrack, textTrack to switch  audio tracks and subtitles

demo project: https://github.com/alexfrompiter/VlcPlayer.git.  - get vlc lib from my branch
tested on ios and android

P.S. 
VideoInfo:
Unfortunately, I wasn't able to use iOS/android native callback function for get video information 
( I tried ios mediaMetaDataDidChange, mediaDidFinishParsing and android Media.Event.ParsedChanged)
I used changing the number of audio tracks > 0 in the onBuffering event




