### PR TITLE
ios: restore usage of initOptions

### DIFF
--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -115,11 +115,9 @@ static NSString *const playbackRate = @"rate";
     _player.scaleFactor = 0;
     VLCMedia *media = [VLCMedia mediaWithURL:_uri];
 
-    NSMutableDictionary *options = [NSMutableDictionary new];
-    [options setObject:@"1" forKey:@"rtsp-tcp"];
-    [options setObject:@"1000" forKey:@"input-repeat"];
-    [media addOptions:[options copy]];
-    options = nil;
+    for (NSString* option in initOptions) {
+        [media addOption:[option stringByReplacingOccurrencesOfString:@"--" withString:@""]];
+    }
 
     _player.media = media;
     _player.media.delegate = self;
@@ -154,11 +152,9 @@ static NSString *const playbackRate = @"rate";
 
     VLCMedia *media = [VLCMedia mediaWithURL:_uri];
 
-    NSMutableDictionary *options = [NSMutableDictionary new];
-    [options setObject:@"1" forKey:@"rtsp-tcp"];
-    [options setObject:@"1000" forKey:@"input-repeat"];
-    [media addOptions:[options copy]];
-    options = nil;
+    for (NSString* option in initOptions) {
+        [media addOption:[option stringByReplacingOccurrencesOfString:@"--" withString:@""]];
+    }
 
     _player.media = media;
     _player.media.delegate = self;


### PR DESCRIPTION
This reverts commit b1022f4e8d4bcaa75c9f710bfadb64024a2709d8.

### Reason:

* which ignores and breaks the initOptions entirely.
* seems both `addOption` and `addOptions` are exist and valid in the official doc and exist in both v3.6.0 and v4.0

So revert that commit to restore initOptions usage (align with android).


@mechazod is there anything I've missed?


doc:
https://videolan.videolan.me/VLCKit/interface_v_l_c_media.html#ab09b1de8ddcfae6c2ecc331777d54119

header:
https://code.videolan.org/videolan/VLCKit/-/blob/master/Headers/Public/VLCMedia.h#L385

impl:
https://code.videolan.org/videolan/VLCKit/-/blob/master/Sources/VLCMedia.m#L381