### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.facebook.react:react-native:+"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'org.videolan.android:libvlc-all:3.6.0-eap5'
+    implementation 'org.videolan.android:libvlc-all:3.6.0-eap9'
 }


### PR DESCRIPTION
update to file build.gradle implementation 'org.videolan.android:libvlc-all:3.6.0-eap9'

fix: [#162](https://github.com/razorRun/react-native-vlc-media-player/issues/162)

thanks to: @tunm1228 