### PR TITLE
[config-plugin] remove console.log

### DIFF
--- a/expo/ios/withMobileVlcKit.js
+++ b/expo/ios/withMobileVlcKit.js
@@ -6,7 +6,6 @@ const fs = require("fs");
 const withMobileVlcKit = (config, options) => {
     // No need if you are running RN 0.61 and up
     if (!options?.ios?.includeVLCKit) {
-        console.log("okok");
         return config;
     }
 


### PR DESCRIPTION
`console.log` in a config plugin will break prebuild on Expo. 

<img width="775" alt="image" src="https://github.com/razorRun/react-native-vlc-media-player/assets/852069/4b52f7ae-6188-42e6-84b1-c638bee55ade">

I've removed the log line.
