### PR TITLE
ci: add npm publish beta workflow

### DIFF
--- a/.github/workflows/npmpublish-beta.yml
+++ b/.github/workflows/npmpublish-beta.yml
@@ -1,0 +1,35 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package Beta
+
+on:
+  # Trigger the workflow from any feature branch
+  workflow_dispatch:
+    inputs:
+      betaVersion:
+        description: "Version tag for the beta job"
+        required: true
+        type: number
+jobs:
+  publish-npm-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: Set Git Environment and Update package number
+        run: |
+          sudo apt upgrade && sudo apt install jq -y
+          npm --no-git-tag-version version patch
+          currentVersion=$(jq --raw-output '.version' package.json)
+          git config --global user.name 'GIT Package Updater'
+          git config --global user.email 'razorRun@users.noreply.github.com'
+          npm -f version "$currentVersion-beta.${{ github.event.inputs.betaVersion }}"
+          git push
+      - run: npm ci
+      - run: npm publish --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
To add a new workflow to publish beta releases for the next upcoming release.

Should be used to deploy a beta version for the new Swift version.
https://github.com/razorRun/react-native-vlc-media-player/pull/163