### PR TITLE
perf(android): optimizing heavy onProgress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,9 @@ dist
 .pnp.*
 
 # Android
-#
 .gradle
+build/
+
+# MacOS
+.DS_Store
+

--- a/VLCPlayer.js
+++ b/VLCPlayer.js
@@ -169,8 +169,9 @@ export default class VLCPlayer extends Component {
       onVideoStopped: this._onStopped,
       onVideoBuffering: this._onBuffering,
       onVideoLoad: this._onLoad,
-      progressUpdateInterval: 250,
+      progressUpdateInterval: this.props.onProgress ? 250 : 0,
     });
+
     return <RCTVLCPlayer ref={this._assignRoot} {...nativeProps} />;
   }
 }

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
@@ -94,7 +94,7 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     }
 
 
-    @ReactProp(name = PROP_PROGRESS_UPDATE_INTERVAL, defaultFloat = 250.0f )
+    @ReactProp(name = PROP_PROGRESS_UPDATE_INTERVAL, defaultFloat = 0f )
     public void setInterval(final ReactVlcPlayerView videoView, final float interval) {
         videoView.setmProgressUpdateInterval(interval);
     }

--- a/playerView/VLCPlayerView.js
+++ b/playerView/VLCPlayerView.js
@@ -162,7 +162,6 @@ export default class VLCPlayerView extends Component {
           onPlaying={this.onPlaying.bind(this)}
           onBuffering={this.onBuffering.bind(this)}
           onPaused={this.onPaused.bind(this)}
-          progressUpdateInterval={250}
           onError={this._onError}
           onOpen={this._onOpen}
           onLoadStart={this._onLoadStart}


### PR DESCRIPTION
# Optimizing heavy onProgress to Android

This PR optimizes onProgress prop on Android, avoiding run in main thread or when isn't necessary, avoiding app performance issues.

## Fixes

- [X] Creating a new thread to perform onProgress actions
- [X] Avoid tracking progress actions if onProgress not provided

## Motivation

When trying to render multiple players, performance issues was occurring when trying to execute actions like back screen fast, because multiple onProgress tracking was being triggered in the main thread. It was impacting user experience a lot.

| Before | After |
| ---- | ---- |
| <video src="https://github.com/razorRun/react-native-vlc-media-player/assets/30243834/152b5a64-efba-4659-99e4-858b864388e2" />  | <video src="https://github.com/razorRun/react-native-vlc-media-player/assets/30243834/18edf048-30ea-416f-be95-49e1b88e20fd" />|









