### PR TITLE
release media object after setMedia

### DIFF
--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -399,6 +399,7 @@ class ReactVlcPlayerView extends TextureView implements
             }
             mVideoInfo = null;
             mMediaPlayer.setMedia(m);
+            m.release();
             mMediaPlayer.setScale(0);
             if (_subtitleUri != null) {
                 mMediaPlayer.addSlave(Media.Slave.Type.Subtitle, _subtitleUri, true);


### PR DESCRIPTION
This PR fixes #191 caused due to not releasing all the VLC objects (org.videolan.libvlc,Media in this case).