### PR TITLE
If there are no Android options, ignore the Gradle modification

### DIFF
--- a/expo/android/withGradleTasks.js
+++ b/expo/android/withGradleTasks.js
@@ -31,6 +31,9 @@ const resolveAppGradleString = (options) => {
 };
 
 const withGradleTasks = (config, options) => {
+    if(!options || !options.android){
+        return config;
+    }
     return withAppBuildGradle(config, (config) => {
         const newCode = generateCode.mergeContents({
             tag: "withVlcMediaPlayer",


### PR DESCRIPTION
This change solves [this](https://github.com/razorRun/react-native-vlc-media-player/issues/184) problem in the expo environment