### PR TITLE
Add ProGuard rule to fix missing LibVLC error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,7 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"
+        consumerProguardFiles("proguard-rules.pro")
         ndk {
             abiFilters 'armeabi-v7a','x86_64','arm64-v8a','x86'
         }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -26,4 +26,4 @@
 
 # https://github.com/pedroSG94/vlc-example-streamplayer/issues/28
 
--keep class org.videolan.** { *; }
+-keep class org.videolan.libvlc.** { *; }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -23,3 +23,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# https://github.com/pedroSG94/vlc-example-streamplayer/issues/28
+
+-keep class org.videolan.** { *; }


### PR DESCRIPTION
Fixes error `FindClass(org/videolan/libvlc/Media$Track) failed` thrown in ProGuard-enabled Android builds.

Found the suggestion to keep all VLC classes on an issue for a similar library and it's now working:

https://github.com/pedroSG94/vlc-example-streamplayer/issues/28#issuecomment-474928919