### PR TITLE
Fix VLC Player state on iOS

### DIFF
--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -146,6 +146,9 @@ static NSString *const playbackRate = @"rate";
 -(void)setResume:(BOOL)autoplay
 {
     [self createPlayer:nil];
+
+    if(autoplay)
+        [self play];
 }
 
 -(void)setSource:(NSDictionary *)source
@@ -373,7 +376,7 @@ static NSString *const playbackRate = @"rate";
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 
-    if(_player.media)
+    if (_player.media)
         [_player stop];
 
     if (_player)

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -116,6 +116,15 @@ static NSString *const playbackRate = @"rate";
     }
 }
 
+- (void)togglePlayback
+{
+    if (_paused) {
+        [self play];
+    } else {
+        [self pause];
+    }
+}
+
 - (void)setSource:(NSDictionary *)source
 {
     [self createPlayer:source];
@@ -133,17 +142,14 @@ static NSString *const playbackRate = @"rate";
 {
     _paused = paused;
 
-    if (paused)
-        [self pause];
+    [self togglePlayback];
 }
 
 - (void)setResume:(BOOL)resume
 {
-    if (resume) {
-        [self play];
-    } else {
-        [self pause];
-    }
+    _paused = resume;
+    
+    [self togglePlayback];
 }
 
 - (void)setSubtitleUri:(NSString *)subtitleUri

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -30,7 +30,6 @@ static NSString *const playbackRate = @"rate";
 
     NSDictionary * _source;
     BOOL _paused;
-    BOOL _started;
     NSString * _subtitleUri;
 
     NSDictionary * _videoInfo;
@@ -59,20 +58,12 @@ static NSString *const playbackRate = @"rate";
 
 - (void)applicationWillResignActive:(NSNotification *)notification
 {
-    if (!_paused) {
-        [self setPaused:_paused];
-    }
+    [self play];
 }
 
 - (void)applicationWillEnterForeground:(NSNotification *)notification
 {
-    [self applyModifiers];
-}
-
-- (void)applyModifiers
-{
-    if(!_paused)
-        [self play];
+    [self pause];
 }
 
 - (void)setAutoplay:(BOOL)autoplay
@@ -82,23 +73,22 @@ static NSString *const playbackRate = @"rate";
 
 - (void)setPaused:(BOOL)paused
 {
-    if(_player){
-        if(!paused){
-            [self play];
-        }else {
-            [_player pause];
-            _paused =  YES;
-            _started = NO;
-        }
-    }
+    _paused = paused;
 }
 
 -(void)play
 {
-    if(_player){
+    if (_player) {
         [_player play];
         _paused = NO;
-        _started = YES;
+    }
+}
+
+- (void)pause
+{
+    if (_player) {
+        [_player pause];
+        _paused = YES;
     }
 }
 

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -102,14 +102,16 @@ static NSString *const playbackRate = @"rate";
     }
 }
 
--(void)setResume:(BOOL)autoplay
+-(void)createPlayer:(NSDictionary *)source
 {
-}
+    if (_player) {
+        [self _release];
+    }
 
--(void)setSource:(NSDictionary *)source
-{
-    _source = source;
-    _videoInfo = nil;
+    if (source) {
+        _source = source;
+        _videoInfo = nil;
+    }
 
     // [bavv edit start]
     NSString* uri    = [_source objectForKey:@"uri"];
@@ -139,6 +141,16 @@ static NSString *const playbackRate = @"rate";
 
     if(_autoplay)
         [_player play];
+}
+
+-(void)setResume:(BOOL)autoplay
+{
+    [self createPlayer:nil];
+}
+
+-(void)setSource:(NSDictionary *)source
+{
+    [self createPlayer:source];
 }
 
 - (void)setSubtitleUri:(NSString *)subtitleUri

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -102,6 +102,10 @@ static NSString *const playbackRate = @"rate";
     }
 }
 
+-(void)setResume:(BOOL)autoplay
+{
+}
+
 -(void)setSource:(NSDictionary *)source
 {
     _source = source;

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -70,7 +70,7 @@ static NSString *const playbackRate = @"rate";
 
 - (void)createPlayer:(NSDictionary *)source
 {
-    if(_player){
+    if (_player){
         [self _release];
     }
 
@@ -99,7 +99,8 @@ static NSString *const playbackRate = @"rate";
     self.onVideoLoadStart(@{
                            @"target": self.reactTag
                            });
-    if(_subtitleUri) {
+
+    if (_subtitleUri) {
         [_player addPlaybackSlave:_subtitleUri type:VLCMediaPlaybackSlaveTypeSubtitle enforce:YES];
     }
 }
@@ -138,7 +139,7 @@ static NSString *const playbackRate = @"rate";
 {
     _autoplay = autoplay;
 
-    if(autoplay)
+    if (autoplay)
         [self play];
 }
 
@@ -159,7 +160,8 @@ static NSString *const playbackRate = @"rate";
 - (void)setSubtitleUri:(NSString *)subtitleUri
 {
     _subtitleUri = [NSURL URLWithString:subtitleUri];
-    if(_player) {
+
+    if (_player) {
         [_player addPlaybackSlave:_subtitleUri type:VLCMediaPlaybackSlaveTypeSubtitle enforce:YES];
     }
 }
@@ -177,7 +179,7 @@ static NSString *const playbackRate = @"rate";
      NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
      NSLog(@"userInfo %@",[aNotification userInfo]);
      NSLog(@"standardUserDefaults %@",defaults);
-    if(_player){
+    if (_player){
         VLCMediaPlayerState state = _player.state;
         switch (state) {
             case VLCMediaPlayerStateOpening:
@@ -201,7 +203,7 @@ static NSString *const playbackRate = @"rate";
                 break;
             case VLCMediaPlayerStateBuffering:
                 NSLog(@"VLCMediaPlayerStateBuffering %i", _player.numberOfAudioTracks);
-                if(!_videoInfo && _player.numberOfAudioTracks > 0) {
+                if (!_videoInfo && _player.numberOfAudioTracks > 0) {
                     _videoInfo = [self getVideoInfo];
                     self.onVideoLoad(_videoInfo);
                 }
@@ -262,12 +264,12 @@ static NSString *const playbackRate = @"rate";
 
 - (void)updateVideoProgress
 {
-    if(_player){
+    if (_player){
         int currentTime   = [[_player time] intValue];
         int remainingTime = [[_player remainingTime] intValue];
         int duration      = [_player.media.length intValue];
 
-        if( currentTime >= 0 && currentTime < duration) {
+        if ( currentTime >= 0 && currentTime < duration) {
             self.onVideoProgress(@{
                                    @"target": self.reactTag,
                                    @"currentTime": [NSNumber numberWithInt:currentTime],
@@ -284,55 +286,58 @@ static NSString *const playbackRate = @"rate";
     NSMutableDictionary *info = [NSMutableDictionary new];
     info[@"duration"] = _player.media.length.value;
     int i;
-    if(_player.videoSize.width > 0) {
+    if (_player.videoSize.width > 0) {
         info[@"videoSize"] =  @{
             @"width":  @(_player.videoSize.width),
             @"height": @(_player.videoSize.height)
         };
     }
-   if(_player.numberOfAudioTracks > 0) {
-        NSMutableArray *tracks = [NSMutableArray new];
-        for (i = 0; i < _player.numberOfAudioTracks; i++) {
-            if(_player.audioTrackIndexes[i] && _player.audioTrackNames[i]) {
-                [tracks addObject:  @{
-                    @"id": _player.audioTrackIndexes[i],
-                    @"name":  _player.audioTrackNames[i]
-                }];
+
+    if (_player.numberOfAudioTracks > 0) {
+            NSMutableArray *tracks = [NSMutableArray new];
+            for (i = 0; i < _player.numberOfAudioTracks; i++) {
+                if (_player.audioTrackIndexes[i] && _player.audioTrackNames[i]) {
+                    [tracks addObject:  @{
+                        @"id": _player.audioTrackIndexes[i],
+                        @"name":  _player.audioTrackNames[i]
+                    }];
+                }
             }
+            info[@"audioTracks"] = tracks;
         }
-        info[@"audioTracks"] = tracks;
-    }
-    if(_player.numberOfSubtitlesTracks > 0) {
-        NSMutableArray *tracks = [NSMutableArray new];
-        for (i = 0; i < _player.numberOfSubtitlesTracks; i++) {
-            if(_player.videoSubTitlesIndexes[i] && _player.videoSubTitlesNames[i]) {
-                [tracks addObject:  @{
-                    @"id": _player.videoSubTitlesIndexes[i],
-                    @"name":  _player.videoSubTitlesNames[i]
-                }];
+
+        if (_player.numberOfSubtitlesTracks > 0) {
+            NSMutableArray *tracks = [NSMutableArray new];
+            for (i = 0; i < _player.numberOfSubtitlesTracks; i++) {
+                if (_player.videoSubTitlesIndexes[i] && _player.videoSubTitlesNames[i]) {
+                    [tracks addObject:  @{
+                        @"id": _player.videoSubTitlesIndexes[i],
+                        @"name":  _player.videoSubTitlesNames[i]
+                    }];
+                }
             }
+            info[@"textTracks"] = tracks;
         }
-        info[@"textTracks"] = tracks;
-    }
-    return info;
+
+        return info;
 }
 
 - (void)jumpBackward:(int)interval
 {
-    if(interval>=0 && interval <= [_player.media.length intValue])
+    if (interval>=0 && interval <= [_player.media.length intValue])
         [_player jumpBackward:interval];
 }
 
 - (void)jumpForward:(int)interval
 {
-    if(interval>=0 && interval <= [_player.media.length intValue])
+    if (interval>=0 && interval <= [_player.media.length intValue])
         [_player jumpForward:interval];
 }
 
 - (void)setSeek:(float)pos
 {
-    if([_player isSeekable]){
-        if(pos>=0 && pos <= 1){
+    if ([_player isSeekable]){
+        if (pos>=0 && pos <= 1){
             [_player setPosition:pos];
         }
     }
@@ -340,7 +345,7 @@ static NSString *const playbackRate = @"rate";
 
 - (void)setSnapshotPath:(NSString*)path
 {
-    if(_player)
+    if (_player)
         [_player saveVideoSnapshotAt:path withWidth:0 andHeight:0];
 }
 

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -70,6 +70,10 @@ static NSString *const playbackRate = @"rate";
 
 - (void)createPlayer:(NSDictionary *)source
 {
+    if(_player){
+        [self _release];
+    }
+
     _source = source;
     _videoInfo = nil;
 
@@ -79,9 +83,9 @@ static NSString *const playbackRate = @"rate";
     int initType = [_source objectForKey:@"initType"];
     NSDictionary* initOptions = [_source objectForKey:@"initOptions"];
 
-    if(initType == 1) {
+    if (initType == 1) {
         _player = [[VLCMediaPlayer alloc] init];
-    }else {
+    } else {
         _player = [[VLCMediaPlayer alloc] initWithOptions:initOptions];
     }
     _player.delegate = self;

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -145,10 +145,9 @@ static NSString *const playbackRate = @"rate";
 
 -(void)setResume:(BOOL)autoplay
 {
-    [self createPlayer:nil];
+    _autoplay = autoplay;
 
-    if(autoplay)
-        [self play];
+    [self createPlayer:nil];
 }
 
 -(void)setSource:(NSDictionary *)source

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -140,7 +140,7 @@ static NSString *const playbackRate = @"rate";
     }
 
     if(_autoplay)
-        [_player play];
+        [self play];
 }
 
 -(void)setResume:(BOOL)autoplay


### PR DESCRIPTION
This fixes an issue introduced in PR https://github.com/razorRun/react-native-vlc-media-player/pull/227 caused by the following:

```
// Calling
[_player play];

// Instead of
[self play];

The library's VLC Player implementation handles other state with it's own instance method of play
```

Also added a `createPlayer` method to initialize the player and improved the play/pause logic.