### PR TITLE
fix(player): resolve video buffering delay caused by adding an empty subtitle path

### DIFF
--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -100,7 +100,7 @@ static NSString *const playbackRate = @"rate";
                            @"target": self.reactTag
                            });
 
-    if (_subtitleUri) {
+    if (_subtitleUri && !([_subtitleUri  isEqual: @""]) && _player) {
         [_player addPlaybackSlave:_subtitleUri type:VLCMediaPlaybackSlaveTypeSubtitle enforce:YES];
     }
 }
@@ -159,10 +159,12 @@ static NSString *const playbackRate = @"rate";
 
 - (void)setSubtitleUri:(NSString *)subtitleUri
 {
-    _subtitleUri = [NSURL URLWithString:subtitleUri];
-
-    if (_player) {
+    NSURL *url = [NSURL URLWithString:subtitleUri];
+    if (url && ![subtitleUri isEqualToString:@""] && _player) {
+        _subtitleUri = url;
         [_player addPlaybackSlave:_subtitleUri type:VLCMediaPlaybackSlaveTypeSubtitle enforce:YES];
+    } else {
+        NSLog(@"Invalid subtitle URI: %@", subtitleUri);
     }
 }
 

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -95,14 +95,10 @@ static NSString *const playbackRate = @"rate";
     _player.media = [VLCMedia mediaWithURL:_uri];
     
     [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
-    NSLog(@"autoplay: %i",autoplay);
+
     self.onVideoLoadStart(@{
                            @"target": self.reactTag
                            });
-
-    if (_subtitleUri) {
-        [_player addPlaybackSlave:_subtitleUri type:VLCMediaPlaybackSlaveTypeSubtitle enforce:YES];
-    }
 }
 
 - (void)play

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -100,7 +100,7 @@ static NSString *const playbackRate = @"rate";
                            @"target": self.reactTag
                            });
 
-    if (_subtitleUri && !([_subtitleUri  isEqual: @""]) && _player) {
+    if (_subtitleUri) {
         [_player addPlaybackSlave:_subtitleUri type:VLCMediaPlaybackSlaveTypeSubtitle enforce:YES];
     }
 }
@@ -160,7 +160,8 @@ static NSString *const playbackRate = @"rate";
 - (void)setSubtitleUri:(NSString *)subtitleUri
 {
     NSURL *url = [NSURL URLWithString:subtitleUri];
-    if (url && ![subtitleUri isEqualToString:@""] && _player) {
+    
+    if (url.absoluteString.length != 0 && _player) {
         _subtitleUri = url;
         [_player addPlaybackSlave:_subtitleUri type:VLCMediaPlaybackSlaveTypeSubtitle enforce:YES];
     } else {


### PR DESCRIPTION
Fixed an issue where videos without a subtitle path took longer to load. Videos without subtitles now load more quickly.