### PR TITLE
fix(ios): EXC_BAD_ACCESS When Loading Video 

### DIFF
--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -109,10 +109,6 @@ static NSString *const playbackRate = @"rate";
     _player.media = [VLCMedia mediaWithURL:uri];
     
     [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
-
-    self.onVideoLoadStart(@{
-                           @"target": self.reactTag
-                           });
 }
 
 - (void)setAutoplay:(BOOL)autoplay
@@ -176,6 +172,9 @@ static NSString *const playbackRate = @"rate";
                 self.onVideoOpen(@{
                                      @"target": self.reactTag
                                      });
+                self.onVideoLoadStart(@{
+                                           @"target": self.reactTag
+                                           });
                 break;
             case VLCMediaPlayerStatePaused:
                 _paused = YES;


### PR DESCRIPTION
There has been an issue (https://github.com/razorRun/react-native-vlc-media-player/issues/42#issue-737573847) for a long time regarding http video playback on iOS, which has not been resolved so far. This commit solves this problem.  It was manually tested that onLoadStart is working correctly. You can check with me.