### PR TITLE
fix: position on seek

### DIFF
--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -486,14 +486,8 @@ class ReactVlcPlayerView extends TextureView implements
     /**
      * 视频进度调整
      *
-     * @param time
+     * @param position
      */
-    public void seekTo(long time) {
-        if (mMediaPlayer != null) {
-            mMediaPlayer.setTime(time);
-        }
-    }
-
     public void setPosition(float position) {
         if (mMediaPlayer != null) {
             if (position >= 0 && position <= 1) {

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
@@ -28,7 +28,6 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     private static final String PROP_SEEK = "seek";
     private static final String PROP_RESUME = "resume";
     private static final String PROP_RATE = "rate";
-    private static final String PROP_POSITION = "position";
     private static final String PROP_VIDEO_ASPECT_RATIO = "videoAspectRatio";
     private static final String PROP_SRC_IS_NETWORK = "isNetwork";
     private static final String PROP_SNAPSHOT_PATH = "snapshotPath";
@@ -117,8 +116,7 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
 
     @ReactProp(name = PROP_SEEK)
     public void setSeek(final ReactVlcPlayerView videoView, final float seek) {
-        videoView.seekTo(Math.round(seek * 1000f));
-        //videoView.seekTo(seek);
+        videoView.setPosition(seek);
     }
 
     @ReactProp(name = PROP_AUTO_ASPECT_RATIO, defaultBoolean = false)
@@ -136,13 +134,6 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     public void setRate(final ReactVlcPlayerView videoView, final float rate) {
         videoView.setRateModifier(rate);
     }
-
-    @ReactProp(name = PROP_POSITION)
-    public void setPosition(final ReactVlcPlayerView videoView, final float potision) {
-        videoView.setPosition(potision);
-    }
-
-
 
     @ReactProp(name = PROP_VIDEO_ASPECT_RATIO)
     public void setVideoAspectRatio(final ReactVlcPlayerView videoView, final String aspectRatio) {


### PR DESCRIPTION
Now the behavior when changing seek on android and iOS will be the same (as described in the documentation)

https://github.com/razorRun/react-native-vlc-media-player/pull/234#issue-2856360426 
This pull request can be closed