### PR TITLE
Add onError lifecycle to VLCPlayerView

### DIFF
--- a/playerView/VLCPlayerView.js
+++ b/playerView/VLCPlayerView.js
@@ -54,7 +54,7 @@ export default class VLCPlayerView extends Component {
     playInBackground: false,
     isGG: false,
     autoplay: true,
-    errorTitle: 'Error play video, please try again'
+    errorTitle: 'error'
   };
 
   componentDidMount() {
@@ -85,6 +85,7 @@ export default class VLCPlayerView extends Component {
   render() {
     let {
       onEnd,
+      onError,
       style,
       isGG,
       type,
@@ -162,7 +163,9 @@ export default class VLCPlayerView extends Component {
           onPlaying={this.onPlaying.bind(this)}
           onBuffering={this.onBuffering.bind(this)}
           onPaused={this.onPaused.bind(this)}
+          progressUpdateInterval={250}
           onError={this._onError}
+          // onError={this.onError.bind(this)}
           onOpen={this._onOpen}
           onLoadStart={this._onLoadStart}
         />
@@ -330,7 +333,7 @@ export default class VLCPlayerView extends Component {
 
   _onError = e => {
     // [bavv add start]
-    let { onVLCError } = this.props;
+    let { onVLCError, onError } = this.props;
     onVLCError && onVLCError();
     // [bavv add end]
     console.log('_onError');
@@ -339,6 +342,7 @@ export default class VLCPlayerView extends Component {
     this.setState({
       isError: true,
     });
+    onError&&onError()
   };
 
   _onOpen = e => {

--- a/playerView/index.js
+++ b/playerView/index.js
@@ -55,6 +55,10 @@ export default class CommonVideo extends Component {
 
   static propTypes = {
     /**
+     * 视频播放错误
+     */
+    onError: PropTypes.func,
+    /**
      * 视频播放结束
      */
     onEnd: PropTypes.func,
@@ -187,7 +191,7 @@ export default class CommonVideo extends Component {
   }
 
   render() {
-    let { url, ggUrl, showGG, onGGEnd, onEnd, style, height, title, onLeftPress, showBack, showTitle, closeFullScreen, videoAspectRatio, fullVideoAspectRatio } = this.props;
+    let { url, ggUrl, showGG, onGGEnd, onEnd, onError, style, height, title, onLeftPress, showBack, showTitle, closeFullScreen, videoAspectRatio, fullVideoAspectRatio } = this.props;
     let { isEndGG, isFull, currentUrl } = this.state;
     let currentVideoAspectRatio = '';
     if (isFull) {
@@ -294,6 +298,9 @@ export default class CommonVideo extends Component {
             closeFullScreen={this._closeFullScreen}
             onEnd={() => {
               onEnd && onEnd();
+            }}
+            onError={() => {
+              onError && onError();
             }}
           />
         )}


### PR DESCRIPTION
Add onError lifecycle to VLCPlayerView, so that onError can be directly used when VLCPlayerView is used in the project, and onError is a very commonly used lifecycle in the project