### PR TITLE
Add recording and snapshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,16 +180,26 @@ import Orientation from 'react-native-orientation';
 
 Callback props take a function that gets fired on various player events:
 
-| Prop           | Description                                                                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `onPlaying`    | Called when media starts playing returns eg `{target: 9, duration: 99750, seekable: true}`                                                                                                                           |
-| `onProgress`   | Callback containing `position` as a fraction, and `duration`, `currentTime` and `remainingTime` in seconds <br />&nbsp; ◦ &nbsp;eg `{  duration: 99750, position: 0.30, currentTime: 30154, remainingTime: -69594 }` |
-| `onPaused`     | Called when media is paused                                                                                                                                                                                          |
-| `onStopped `   | Called when media is stoped                                                                                                                                                                                          |
-| `onBuffering ` | Called when media is buffering                                                                                                                                                                                       |
-| `onEnded`      | Called when media playing ends                                                                                                                                                                                       |
-| `onError`      | Called when an error occurs whilst attempting to play media                                                                                                                                                          |
-| `onLoad`       | Called when video info is loaded, Callback containing VideoInfo                                                                                                                                                      |
+| Prop                 | Description                                                                                                                                                                                                          |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onPlaying`          | Called when media starts playing returns eg `{target: 9, duration: 99750, seekable: true}`                                                                                                                           |
+| `onProgress`         | Callback containing `position` as a fraction, and `duration`, `currentTime` and `remainingTime` in seconds <br />&nbsp; ◦ &nbsp;eg `{  duration: 99750, position: 0.30, currentTime: 30154, remainingTime: -69594 }` |
+| `onPaused`           | Called when media is paused                                                                                                                                                                                          |
+| `onStopped `         | Called when media is stoped                                                                                                                                                                                          |
+| `onBuffering `       | Called when media is buffering                                                                                                                                                                                       |
+| `onEnded`            | Called when media playing ends                                                                                                                                                                                       |
+| `onError`            | Called when an error occurs whilst attempting to play media                                                                                                                                                          |
+| `onLoad`             | Called when video info is loaded, Callback containing VideoInfo                                                                                                                                                      |
+| `onRecordingCreated` | Called when a new recording is created as the result of `startRecording()` `stopRecording()`                                                                                                                         |
+
+#### Methods props
+
+Methods available on the VLC player ref
+
+| Prop                                | Description                                                                                                       |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `startRecording(directory: string)` | Start recording the current video into the given directory                                                        |
+| `stopRecording()`                   | Stop recording the current video. The final recording file can be obtained from the `onRecordingCreated` callback |
 
 VideoInfo example:
 

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -295,6 +295,12 @@ class ReactVlcPlayerView extends TextureView implements
                     map.putString("type", "TimeChanged");
                     eventEmitter.sendEvent(map, VideoEventEmitter.EVENT_SEEK);
                     break;
+                case MediaPlayer.Event.RecordChanged:
+                    map.putString("type", "RecordingPath");
+                    map.putBoolean("isRecording", event.getRecording());
+                    map.putString("recordPath", event.getRecordPath());
+                    eventEmitter.sendEvent(map, VideoEventEmitter.EVENT_RECORDING_STATE);
+                    break;
                 default:
                     map.putString("type", event.type + "");
                     eventEmitter.onVideoStateChange(map);
@@ -638,6 +644,17 @@ class ReactVlcPlayerView extends TextureView implements
         }
     }
 
+    public void startRecording(String recordingPath) {
+        if(mMediaPlayer == null) return;
+        if(recordingPath != null) {
+            mMediaPlayer.record(recordingPath);
+        }
+    }
+
+    public void stopRecording() {
+        if(mMediaPlayer == null) return;
+        mMediaPlayer.record(null);
+    }
 
     public void cleanUpResources() {
         if (surfaceView != null) {

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
@@ -3,6 +3,8 @@ package com.yuanzhou.vlc.vlcplayer;
 import android.content.Context;
 import android.text.TextUtils;
 
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -36,6 +38,7 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     private static final String PROP_PROGRESS_UPDATE_INTERVAL = "progressUpdateInterval";
     private static final String PROP_TEXT_TRACK = "textTrack";
     private static final String PROP_AUDIO_TRACK = "audioTrack";
+    private static final String PROP_RECORDING_PATH = "recordingPath";
 
 
     @Override
@@ -153,6 +156,41 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     @ReactProp(name = PROP_TEXT_TRACK)
     public void setTextTrack(final ReactVlcPlayerView videoView, final int textTrack) {
         videoView.setTextTrack(textTrack);
+    }
+
+    public void startRecording(final ReactVlcPlayerView videoView, final String recordingPath) {
+        videoView.startRecording(recordingPath);
+    }
+
+    public void stopRecording(final ReactVlcPlayerView videoView) {
+        videoView.stopRecording();
+    }
+
+    @Override
+    public Map<String, Integer> getCommandsMap() {
+        return MapBuilder.of(
+            "startRecording", 1,
+            "stopRecording", 2
+        );
+    }
+
+    @Override
+    public void receiveCommand(ReactVlcPlayerView root, int commandId, @Nullable ReadableArray args) {
+        switch (commandId) {
+            case 1:
+                if (args != null && args.size() > 0 && !args.isNull(0)) {
+                    String path = args.getString(0);
+                    root.startRecording(path);
+                }
+                break;
+
+            case 2:
+                root.stopRecording();
+                break;
+
+            default:
+                break;
+        }
     }
 
     private boolean startsWithValidScheme(String uriString) {

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/VideoEventEmitter.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/VideoEventEmitter.java
@@ -37,6 +37,7 @@ class VideoEventEmitter {
     public static final String EVENT_ON_VIDEO_BUFFERING = "onVideoBuffering";
     public static final String EVENT_ON_PAUSED = "onVideoPaused";
     public static final String EVENT_ON_LOAD = "onVideoLoad";
+    public static final String EVENT_RECORDING_STATE = "onRecordingState";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -51,7 +52,8 @@ class VideoEventEmitter {
             EVENT_ON_VIDEO_BUFFERING,
             EVENT_ON_ERROR,
             EVENT_ON_VIDEO_STOPPED,
-            EVENT_ON_LOAD
+            EVENT_ON_LOAD,
+            EVENT_RECORDING_STATE
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -68,7 +70,8 @@ class VideoEventEmitter {
             EVENT_ON_VIDEO_BUFFERING,
             EVENT_ON_ERROR,
             EVENT_ON_VIDEO_STOPPED,
-            EVENT_ON_LOAD
+            EVENT_ON_LOAD,
+            EVENT_RECORDING_STATE
     })
 
     @interface VideoEvents {

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,6 +166,13 @@ export type VLCPlayerCallbackProps = {
    * @param event - Event properties
    */
   onLoad?: (event: VideoInfo) => void;
+
+    /**
+   * Called when a new recording is created
+   *
+   * @param recordingPath - Full path to the recording file
+   */
+    onRecordingCreated?: (recordingPath: string) => void;
 };
 
 export type VLCPlayerProps = VLCPlayerCallbackProps & {
@@ -264,10 +271,32 @@ export type VLCPlayerProps = VLCPlayerCallbackProps & {
 /**
  * A component that can be used to show a playback
  */
-declare class VLCPlayer extends Component<VLCPlayerProps> {}
+declare class VLCPlayer extends Component<VLCPlayerProps> {
+  /**
+   * Start a new recording session at the given path
+   * @param path Directory to create new recording in
+   */
+  startRecording(path: string);
+
+  /**
+   * Stop current recording session
+   */
+  stopRecording();
+}
 
 /**
  * A component that renders a playback with additional
  * features like fullscreen, controls, etc.
  */
-declare class VlCPlayerView extends Component<any> {}
+declare class VlCPlayerView extends Component<any> {
+  /**
+   * Start a new recording session at the given path
+   * @param path Directory to create new recording in
+   */
+  startRecording(path: string);
+
+  /**
+   * Stop current recording session
+   */
+  stopRecording();
+}

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.h
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.h
@@ -14,9 +14,11 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoOpen;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoadStart;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoad;
+@property (nonatomic, copy) RCTBubblingEventBlock onRecordingState;
 
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 - (void)setMuted:(BOOL)value;
-
+- (void)startRecording:(NSString*)path;
+- (void)stopRecording;
 @end

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -251,6 +251,16 @@ static NSString *const playbackRate = @"rate";
     NSLog(@"VLCMediaMetaDataDidChange %i", _player.numberOfAudioTracks);
 }
 
+- (void)mediaPlayer:(VLCMediaPlayer *)player recordingStoppedAtPath:(NSString *)path {
+    if (self.onRecordingState) {
+        self.onRecordingState(@{
+            @"target": self.reactTag,
+            @"isRecording": @NO,
+            @"recordPath": path ?: [NSNull null]
+        });
+    }
+}
+
 //   ===================================
 
 - (void)updateVideoProgress
@@ -351,6 +361,23 @@ static NSString *const playbackRate = @"rate";
 - (void)setTextTrack:(int)track
 {
     [_player setCurrentVideoSubTitleIndex:track];
+}
+
+- (void)startRecording:(NSString*)path
+{
+    [_player startRecordingAtPath:path];
+    if (self.onRecordingState) {
+        self.onRecordingState(@{
+            @"target": self.reactTag,
+            @"isRecording": @YES,
+            @"recordPath": path ?: [NSNull null]
+        });
+    }
+}
+
+- (void)stopRecording
+{
+    [_player stopRecording];
 }
 
 

--- a/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
@@ -1,6 +1,7 @@
 #import "RCTVLCPlayerManager.h"
 #import "RCTVLCPlayer.h"
 #import "React/RCTBridge.h"
+#import "React/RCTUIManager.h"
 
 @implementation RCTVLCPlayerManager
 
@@ -24,6 +25,7 @@ RCT_EXPORT_VIEW_PROPERTY(onVideoError, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoOpen, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onRecordingState, RCTDirectEventBlock);
 
 - (dispatch_queue_t)methodQueue
 {
@@ -46,5 +48,27 @@ RCT_CUSTOM_VIEW_PROPERTY(muted, BOOL, RCTVLCPlayer)
 RCT_EXPORT_VIEW_PROPERTY(audioTrack, int);
 RCT_EXPORT_VIEW_PROPERTY(textTrack, int);
 RCT_EXPORT_VIEW_PROPERTY(autoplay, BOOL);
+
+RCT_EXPORT_METHOD(startRecording:(nonnull NSNumber*) reactTag withPath:(NSString *)path) {
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        RCTVLCPlayer *view = viewRegistry[reactTag];
+        if (!view || ![view isKindOfClass:[RCTVLCPlayer class]]) {
+            RCTLogError(@"Cannot find RCTVLCPlayer with tag #%@", reactTag);
+            return;
+        }
+        [view startRecording:path];
+    }];
+}
+
+RCT_EXPORT_METHOD(stopRecording:(nonnull NSNumber*) reactTag) {
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        RCTVLCPlayer *view = viewRegistry[reactTag];
+        if (!view || ![view isKindOfClass:[RCTVLCPlayer class]]) {
+            RCTLogError(@"Cannot find RCTVLCPlayer with tag #%@", reactTag);
+            return;
+        }
+        [view stopRecording];
+    }];
+}
 
 @end


### PR DESCRIPTION
## Recording

Add support to record the current VLC session. This allows for features like capturing segments of video from an RTSP stream from a webcam or similar.

The implementation is based on the [similar recording feature](https://github.com/solid-software/flutter_vlc_player/?tab=readme-ov-file#recording-feature) in the `flutter_vlc_player` package.

Call `startRecording(directory)` on a vlc player ref to begin recording and `stopRecording()` to finish. The recording is available from the `onRecordingCreated` callback. Note that it is the vlc library that is responsible for creating the recording so it isn't possible to provide a full path to the recording, only a directory where the recording should be created.

Example usage:

```tsx
function App(): React.JSX.Element {
  const playerRef = useRef<VLCPlayer | null | undefined>(null);
  const tempDirPath = RNFS.TemporaryDirectoryPath;

  return (
    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
      <Button
        title="Start Recording"
        onPress={() => {
          playerRef.current?.startRecording(tempDirPath);
        }}
      />
      <Button
        title="Stop Recording"
        onPress={() => {
          playerRef.current?.stopRecording();
        }}
      />

      <VLCPlayer
        ref={playerRef}
        style={[
          {
            borderColor: 'red',
            borderWidth: 1,
          },
        ]}
        onRecordingCreated={(path) => {
          console.log('New recording saved', path);
        }}
        videoAspectRatio="16:9"
        source={{
          uri: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
        }}
      />
    </View>
  );
}
```

## Snapshots

Adds a new `snapshot()` method to the `VLCPlayer` component which will screenshot the current video frame. The snapshot is returned in the `onSnapshot` callback event.

Example usage:


```tsx
function App(): React.JSX.Element {
  const playerRef = useRef<VLCPlayer | null | undefined>(null);
  const tempDirPath = RNFS.TemporaryDirectoryPath;

  const [snapshotPath, setSnapshotPath] = useState<string | null>(null);

  return (
    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
      <Text>Home Screen</Text>
      <Button
        title="Capture Screenshot"
        onPress={() => {
          console.log(tempDirPath);
          if (!playerRef.current) {
            console.log('No Player!');
          } else {
            console.log('Capture snapshot');
            const dest = `${tempDirPath}/snapshot_${Date.now()}.jpg`;
            playerRef.current?.snapshot(dest);
          }
        }}
      />

      {snapshotPath && (
        <>
          <Text>Snapshot Path: {snapshotPath}</Text>
          <Image
            source={{uri: `file://${snapshotPath}`}}
            style={{width: 300, height: 200}}
          />
        </>
      )}

      <VLCPlayer
        ref={playerRef}
        style={{
          width: 300,
          height: 200,
        }}
        videoAspectRatio="16:9"
        source={{
          uri: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
        }}
        onSnapshot={event => {
          if (event.success) {
            setSnapshotPath(event.path);
          }
        }}
      />
    </View>
  );
}
```