### PR TITLE
Document simulator crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ Video coding formats: Cinepak, Dirac, DV, H.263, H.264/MPEG-4 AVC, H.265/MPEG HE
 4. Send PR.
 5. Be happy, Cause you're a Rockstar 🌟 ❤️
 
+## Known Issues
+
+### iOS 17 Simulator Crash
+
+It is a [known issue](https://code.videolan.org/videolan/VLCKit/-/issues/724) that apps can crash on playback in iOS simulator with `EXEC_BAD_ACCESS` errors. This appears to only be on certain iOS 17.x versions (17.4, 17.5).
+If this happens, try running on an iOS 18+ simulator instead.
+
 ## TODO
 
 1. Android video aspect ratio and other params do not work (Events are called but all events come through a single event onVideoStateChange but the JS side does not implement it)


### PR DESCRIPTION
The playback was crashing for me on an iOS 17.5 simulator. I noticed a [few](https://github.com/razorRun/react-native-vlc-media-player/issues/102) [issues](https://github.com/razorRun/react-native-vlc-media-player/issues/39) related to this but no solution.

As per the [VLCKit issue](https://code.videolan.org/videolan/VLCKit/-/issues/724#note_443338) it appears to just be a problem in that specific Simulator version. To save some people time in future, I've made a note of it in the docs.

Related #102 *and maybe* #39 and #208