### PR TITLE
Fix video always repeating

### DIFF
--- a/VLCPlayer.js
+++ b/VLCPlayer.js
@@ -183,8 +183,14 @@ export default class VLCPlayer extends Component {
     source.isNetwork = isNetwork;
     source.autoplay = this.props.autoplay;
     source.initOptions = source.initOptions || [];
-    //repeat the input media
-    source.initOptions.push("--input-repeat=1000");
+
+    if (this.props.repeat) { 
+      const existingRepeat = source.initOptions.find(item => item.startsWith('--repeat') || item.startsWith('--input-repeat'));
+      if (!existingRepeat) {
+        source.initOptions.push("--repeat");
+      }
+    }
+
     const nativeProps = Object.assign({}, this.props);
     Object.assign(nativeProps, {
       style: [styles.base, nativeProps.style],

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,10 @@ export interface VLCPlayerSource {
    * 
    * `["--network-caching=50", "--rtsp-tcp"]`
    * 
-   * @default ["--input-repeat=1000"]
+   * If `repeat` is set on props this will default to ["--repeat"] unless
+   * another `--repeat` or `--input-repeat` flag is passed.
+   * 
+   * @default []
    */
   initOptions?: string[];
 }


### PR DESCRIPTION
Currently, the `--input-repeat` flag is always added, regardless of any settings, meaning the documented `repeat` option doesn't work. 

The `--repeat` flag is now added only if `repeat` is on in props and no other repeat-related flags are provided.

It also uses `--repeat` instead of a fixed number of 1000 repeats.