### PR TITLE
Add types for undocumented methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -279,10 +279,7 @@ export type VLCPlayerProps = VLCPlayerCallbackProps & {
   autoplay?: boolean;
 };
 
-/**
- * A component that can be used to show a playback
- */
-declare class VLCPlayer extends Component<VLCPlayerProps> {
+declare class PlaybackMethods<T> extends Component<T> {
   /**
    * Start a new recording session at the given path
    * @param path Directory to create new recording in
@@ -296,30 +293,45 @@ declare class VLCPlayer extends Component<VLCPlayerProps> {
 
   /**
    * Take a screenshot of the current video frame
+   *
    * @param path The file path where to save the screenshot
    */
   snapshot(path: string);
+
+  /**
+   * Seek to the given position
+   * 
+   * @param pos Position to seek to (as a percentage of the full duration)
+   */
+  seek(pos: number);
+
+  /**
+   * Resume playback
+   */
+  resume();
+
+  /**
+   * Change auto aspect ratio setting
+   * 
+   * @param useAuto Whether or not to use auto aspect ratio
+   */
+  autoAspectRatio(useAuto: boolean);
+  
+  /**
+   * Update video aspect ratio e.g. `"16:9"`
+   * 
+   * @param ratio Aspect ratio to use
+   */
+  changeVideoAspectRatio(ratio: string);
 }
+
+/**
+ * A component that can be used to show a playback
+ */
+declare class VLCPlayer extends PlaybackMethods<VLCPlayerProps> {}
 
 /**
  * A component that renders a playback with additional
  * features like fullscreen, controls, etc.
  */
-declare class VlCPlayerView extends Component<any> {
-  /**
-   * Start a new recording session at the given path
-   * @param path Directory to create new recording in
-   */
-  startRecording(path: string);
-
-  /**
-   * Stop current recording session
-   */
-  stopRecording();
-
-  /**
-   * Take a screenshot of the current video frame
-   * @param path The file path where to save the screenshot
-   */
-  snapshot(path: string);
-}
+declare class VlCPlayerView extends PlaybackMethods<any> {}


### PR DESCRIPTION
Some methods in `VLCPlayer.js` exist and were functional but did not have typings so TypeScript complained when you tried to use them. These have been added to the declarations.

Assuming

```ts
const playerRef = useRef<VLCPlayer | null>(null);
```

Before:

<img width="655" alt="image" src="https://github.com/user-attachments/assets/43ad2cbc-fb33-4f90-b185-2ed3bd437cf1" />

After:

<img width="645" alt="image" src="https://github.com/user-attachments/assets/4a73dc17-3cf6-46d9-92f8-47398c32732e" />

The declarations have also been cleaned up to use a single base class for methods shared across `VLCPlayer` and `VlCPlayerView` to remove someduplication.