### PR TITLE
Fix `onRecordingCreated` being called twice

### DIFF
--- a/VLCPlayer.js
+++ b/VLCPlayer.js
@@ -147,8 +147,8 @@ export default class VLCPlayer extends Component {
       return;
     }
 
-    this.lastRecording = event.nativeEvent.recordPath;
-    if (this.lastRecording && this.props.onRecordingCreated) {
+    if (!event.nativeEvent.isRecording && event.nativeEvent.recordPath) {
+      this.lastRecording = event.nativeEvent.recordPath;
       this.props.onRecordingCreated(this.lastRecording);
     }
   }

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -301,7 +301,11 @@ class ReactVlcPlayerView extends TextureView implements
                 case MediaPlayer.Event.RecordChanged:
                     map.putString("type", "RecordingPath");
                     map.putBoolean("isRecording", event.getRecording());
-                    map.putString("recordPath", event.getRecordPath());
+                    // Record started emits and event with the record path (but no file).
+                    // Only want to emit when recording has stopped and the recording is created.
+                    if(!event.getRecording() && event.getRecordPath() != null) {
+                        map.putString("recordPath", event.getRecordPath());
+                    }
                     eventEmitter.sendEvent(map, VideoEventEmitter.EVENT_RECORDING_STATE);
                     break;
                 default:

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -369,8 +369,7 @@ static NSString *const playbackRate = @"rate";
     if (self.onRecordingState) {
         self.onRecordingState(@{
             @"target": self.reactTag,
-            @"isRecording": @YES,
-            @"recordPath": path ?: [NSNull null]
+            @"isRecording": @YES
         });
     }
 }


### PR DESCRIPTION
Closes #259 

Record event was being sent twice, once on start record and again on end. The recording path is no longer sent on record start (as it is just a directory, not a full file path) so JS can skip calling the callback.