### PR TITLE
Adds an option to accept self signed certificates

### DIFF
--- a/VLCPlayer.js
+++ b/VLCPlayer.js
@@ -243,6 +243,7 @@ VLCPlayer.propTypes = {
   muted: PropTypes.bool,
   audioTrack: PropTypes.number,
   textTrack: PropTypes.number,
+  acceptInvalidCertificates: PropTypes.bool,
 
   onVideoLoadStart: PropTypes.func,
   onVideoError: PropTypes.func,

--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerViewManager.java
@@ -38,6 +38,7 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     private static final String PROP_TEXT_TRACK = "textTrack";
     private static final String PROP_AUDIO_TRACK = "audioTrack";
     private static final String PROP_RECORDING_PATH = "recordingPath";
+    private static final String PROP_ACCEPT_INVALID_CERTIFICATES = "acceptInvalidCertificates";
 
 
     @Override
@@ -150,6 +151,11 @@ public class ReactVlcPlayerViewManager extends SimpleViewManager<ReactVlcPlayerV
     @ReactProp(name = PROP_TEXT_TRACK)
     public void setTextTrack(final ReactVlcPlayerView videoView, final int textTrack) {
         videoView.setTextTrack(textTrack);
+    }
+
+    @ReactProp(name = PROP_ACCEPT_INVALID_CERTIFICATES, defaultBoolean = false)
+    public void setAcceptInvalidCertificates(final ReactVlcPlayerView videoView, final boolean accept) {
+        videoView.setAcceptInvalidCertificates(accept);
     }
 
     public void startRecording(final ReactVlcPlayerView videoView, final String recordingPath) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -280,6 +280,15 @@ export type VLCPlayerProps = VLCPlayerCallbackProps & {
    * @default true
    */
   autoplay?: boolean;
+
+  /**
+   * Set to `true` to automatically accept invalid SSL/TLS certificates
+   * when connecting to HTTPS streams. This bypasses certificate validation
+   * which may pose security risks.
+   *
+   * @default false
+   */
+  acceptInvalidCertificates?: boolean;
 };
 
 declare class PlaybackMethods<T> extends Component<T> {

--- a/ios/RCTVLCPlayer/RCTVLCPlayer.h
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.h
@@ -1,8 +1,13 @@
 #import "React/RCTView.h"
+#if TARGET_OS_TV
+#import <TVVLCKit/TVVLCKit.h>
+#else
+#import <MobileVLCKit/MobileVLCKit.h>
+#endif
 
 @class RCTEventDispatcher;
 
-@interface RCTVLCPlayer : UIView
+@interface RCTVLCPlayer : UIView <VLCCustomDialogRendererProtocol>
 
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoProgress;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoPaused;
@@ -17,6 +22,8 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onRecordingState;
 @property (nonatomic, copy) RCTBubblingEventBlock onSnapshot;
 
+@property (nonatomic, strong) VLCDialogProvider *dialogProvider;
+@property (nonatomic, assign) BOOL acceptInvalidCertificates;
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 - (void)setMuted:(BOOL)value;

--- a/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayerManager.m
@@ -49,6 +49,7 @@ RCT_CUSTOM_VIEW_PROPERTY(muted, BOOL, RCTVLCPlayer)
 RCT_EXPORT_VIEW_PROPERTY(audioTrack, int);
 RCT_EXPORT_VIEW_PROPERTY(textTrack, int);
 RCT_EXPORT_VIEW_PROPERTY(autoplay, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(acceptInvalidCertificates, BOOL);
 
 RCT_EXPORT_METHOD(startRecording:(nonnull NSNumber*) reactTag withPath:(NSString *)path) {
     [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {


### PR DESCRIPTION
This PR adds an option to skip SSL certificate validation, or better yet to accept SSL certificates that fail the validation. It does this by using the dialog API's of libvlc. When the option is set and a dialog is asked to be presented for verifying whether the user accepts the insecure link, the dialog will be auto-accepted.