### PR TITLE
fix: missing package name on build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 android {
+    namespace 'com.yuanzhou.vlc'
     compileSdkVersion 35
 
     defaultConfig {


### PR DESCRIPTION
…edia-player/pull/268 change

this should fix https://github.com/razorRun/react-native-vlc-media-player/pull/268#discussion_r2321198229