### PR TITLE
Upgrade to vlc libraries, compatible with Android's 16Kb pagesize requirements

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,5 +44,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.facebook.react:react-native:+"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'org.videolan.android:libvlc-all:3.6.0-eap9'
+    implementation 'org.videolan.android:libvlc-all:3.6.3'
 }


### PR DESCRIPTION
Fixes: https://github.com/razorRun/react-native-vlc-media-player/issues/275

Note: It would be good if this is tested on a wider range of Android devices before being merged. 