### PR TITLE
Replace jcenter() with mavenCentral() in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ repositories {
         url "https://mvnrepository.com/artifact/org.videolan.android"
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
This PR updates the repository configuration in `android/build.gradle` to replace the deprecated `jcenter()` repository with `mavenCentral()`.

## Problem
JCenter was [officially shut down by JFrog on February 1, 2022](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). As of Gradle 7.0+, `jcenter()` is deprecated, and in Gradle 9.0+, it throws an error:

Could not find method jcenter() for arguments [] on repository container

This prevents the library from being used in projects with newer Gradle versions.

## Solution
Replace `jcenter()` with `mavenCentral()` in the repositories block. Maven Central hosts all the same artifacts that were available on JCenter and is the recommended alternative.