### PR TITLE
fix-android   addLifecycleEventListener

### DIFF
--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -91,6 +91,7 @@ class ReactVlcPlayerView extends TextureView implements
         this.setSurfaceTextureListener(this);
 
         this.addOnLayoutChangeListener(onLayoutChangeListener);
+        context.addLifecycleEventListener(this);
     }
 
 


### PR DESCRIPTION
in android
When the app moves to the background during video playback, the video continues playing.

fix  code  one line 
```
class ReactVlcPlayerView extends TextureView ... {
    public ReactVlcPlayerView(ThemedReactContext context) {
        //...

        context.addLifecycleEventListener(this);
    }
}
```