### PR TITLE
Fix VLC player release guards to prevent post-release calls

### DIFF
--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -65,6 +65,7 @@ class ReactVlcPlayerView extends TextureView implements
 
     private boolean isPaused = true;
     private boolean isHostPaused = false;
+    private boolean isReleased = false;
     private int preVolume = 100;
     private boolean autoAspectRatio = false;
     private boolean acceptInvalidCertificates = false;
@@ -133,7 +134,7 @@ class ReactVlcPlayerView extends TextureView implements
 
     @Override
     public void onHostPause() {
-        if (!isPaused && mMediaPlayer != null) {
+        if (!isPaused && mMediaPlayer != null && !isReleased) {
             isPaused = true;
             isHostPaused = true;
             mMediaPlayer.pause();
@@ -206,7 +207,7 @@ class ReactVlcPlayerView extends TextureView implements
             if (view.getWidth() > 0 && view.getHeight() > 0) {
                 mVideoWidth = view.getWidth(); // 获取宽度
                 mVideoHeight = view.getHeight(); // 获取高度
-                if (mMediaPlayer != null) {
+                if (mMediaPlayer != null && !isReleased) {
                     IVLCVout vlcOut = mMediaPlayer.getVLCVout();
                     vlcOut.setWindowSize(mVideoWidth, mVideoHeight);
                     if (autoAspectRatio) {
@@ -376,6 +377,7 @@ class ReactVlcPlayerView extends TextureView implements
             }
             // Create media player
             mMediaPlayer = new MediaPlayer(libvlc);
+            isReleased = false;
             setMutedModifier(mMuted);
             mMediaPlayer.setEventListener(mPlayerListener);
             
@@ -488,8 +490,11 @@ class ReactVlcPlayerView extends TextureView implements
     }
 
     private void releasePlayer() {
-        if (libvlc == null)
+        if (libvlc == null) {
+            isReleased = true;
+            mMediaPlayer = null;
             return;
+        }
 
         final IVLCVout vout = mMediaPlayer.getVLCVout();
         vout.removeCallback(callback);
@@ -498,6 +503,8 @@ class ReactVlcPlayerView extends TextureView implements
         mMediaPlayer.release();
         libvlc.release();
         libvlc = null;
+        mMediaPlayer = null;
+        isReleased = true;
 
         if(mProgressUpdateRunnable != null){
             mProgressUpdateHandler.removeCallbacks(mProgressUpdateRunnable);


### PR DESCRIPTION
App crashes with `IllegalStateException: can't get VLCObject instance` when `ReactVlcPlayerView` calls LibVLC methods after the player has been released (e.g., during layout passes or host pause).

<img width="2856" height="1280" alt="Screenshot_20251222_133223" src="https://github.com/user-attachments/assets/fa105105-f9f0-48df-b5e6-5a150e9cc2fe" />


It seems `releasePlayer()` releases LibVLC but leaves `mMediaPlayer` non-null. `onLayoutChange` and `onHostPause` only check for `mMediaPlayer != null`, so they still call into a released native object.

### Solution:
- Track player lifecycle with an `isReleased` flag.
- Set `isReleased = false` when creating the player, `true` on release.
- Set `mMediaPlayer` to `null` after `releasePlayer()`.
- Guard `onLayoutChange` and `onHostPause` against `isReleased`.

This prevents calls to `setAspectRatio()`/`pause()` on a released player and avoids the crash during layout updates.