### PR TITLE
Prevent portrait stretching by letting LibVLC keep native aspect ratio

### DIFF
--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -210,7 +210,8 @@ class ReactVlcPlayerView extends TextureView implements
                     IVLCVout vlcOut = mMediaPlayer.getVLCVout();
                     vlcOut.setWindowSize(mVideoWidth, mVideoHeight);
                     if (autoAspectRatio) {
-                        mMediaPlayer.setAspectRatio(mVideoWidth + ":" + mVideoHeight);
+                        mMediaPlayer.setAspectRatio(null);
+                        mMediaPlayer.setScale(0);
                     }
                 }
             }
@@ -416,7 +417,8 @@ class ReactVlcPlayerView extends TextureView implements
             if (mVideoWidth > 0 && mVideoHeight > 0) {
                 vlcOut.setWindowSize(mVideoWidth, mVideoHeight);
                 if (autoAspectRatio) {
-                    mMediaPlayer.setAspectRatio(mVideoWidth + ":" + mVideoHeight);
+                    mMediaPlayer.setAspectRatio(null);
+                    mMediaPlayer.setScale(0);
                 }
                 //mMediaPlayer.setAspectRatio(mVideoWidth+":"+mVideoHeight);
             }


### PR DESCRIPTION
In portrait mode, video appears stretched when `autoAspectRatio` is enabled.

The view dimensions are being forced into `setAspectRatio(width:height)`, which stretches the video to the view’s aspect ratio instead of preserving the source ratio.

### Solution

When `autoAspectRatio` is enabled, reset aspect ratio to default (`setAspectRatio(null)`) and use `setScale(0)` so LibVLC preserves the native video aspect ratio (letterboxing instead of stretching).

This only changes behavior when `autoAspectRatio` is true and keeps existing manual `aspectRatio` behavior unchanged.

### Before

<img width="1280" height="2856" alt="Screenshot_20251222_140932" src="https://github.com/user-attachments/assets/fe8b4ec7-20d0-4d7a-af23-8e743501c32e" />

### After

<img width="1280" height="2856" alt="Screenshot_20251222_140732" src="https://github.com/user-attachments/assets/09fe7404-accb-46cb-a6dd-2527bdd16c66" />