### PR TITLE
Fix initType and initOptions parsing on iOS

### DIFF
--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -95,8 +95,8 @@ static NSString *const playbackRate = @"rate";
     // [bavv edit start]
     NSString* uriString = [source objectForKey:@"uri"];
     NSURL* uri = [NSURL URLWithString:uriString];
-    int initType = [source objectForKey:@"initType"];
-    NSDictionary* initOptions = [source objectForKey:@"initOptions"];
+    int initType = [[source objectForKey:@"initType"] intValue];
+    NSArray *initOptions = [source objectForKey:@"initOptions"];
     
     // Get acceptInvalidCertificates from source
     _acceptInvalidCertificates = [[source objectForKey:@"acceptInvalidCertificates"] boolValue];


### PR DESCRIPTION
### Problem
The iOS implementation does not parse `initType` and `initOptions`
from JS source in a type-safe way.

`initType` is assigned directly from an object without conversion,
and `initOptions` may not be treated as an array, which is inconsistent
with the Android implementation.

### Solution
- Safely convert `initType` from NSNumber to int
- Parse `initOptions` as NSArray to match Android behavior

### Result
- Type-safe parameter handling
- Consistent behavior across iOS and Android
- No changes required on JS side
