### PR TITLE
fix(android): setMutedModifier saves preVolume as 0 on init causing unmute to have no audio

### DIFF
--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -578,7 +578,8 @@ class ReactVlcPlayerView extends TextureView implements
         mMuted = muted;
         if (mMediaPlayer != null) {
             if (muted) {
-                this.preVolume = mMediaPlayer.getVolume();
+                int currentVolume = mMediaPlayer.getVolume();
+                this.preVolume = currentVolume > 0 ? currentVolume : 100;
                 mMediaPlayer.setVolume(0);
             } else {
                 mMediaPlayer.setVolume(this.preVolume);


### PR DESCRIPTION
## Problem
When the player initializes with `muted=true`, `setMutedModifier(true)` is called 
immediately after `new MediaPlayer(libvlc)`. At this point `mMediaPlayer.getVolume()` 
returns `0`, so `preVolume` is saved as `0`.

When the user later unmutes, `setVolume(preVolume)` becomes `setVolume(0)`, 
resulting in no audio after unmuting.

## Fix
Prevent `preVolume` from being saved as `0` by falling back to `100`:
```java
int currentVolume = mMediaPlayer.getVolume();
this.preVolume = currentVolume > 0 ? currentVolume : 100;
```