### PR TITLE
fix: restore correct volume when unmuting after initial muted state

### DIFF
--- a/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
+++ b/android/src/main/java/com/yuanzhou/vlc/vlcplayer/ReactVlcPlayerView.java
@@ -587,10 +587,11 @@ class ReactVlcPlayerView extends TextureView implements
         mMuted = muted;
         if (mMediaPlayer != null) {
             if (muted) {
-                this.preVolume = mMediaPlayer.getVolume();
+                int currentVolume = mMediaPlayer.getVolume();
+                this.preVolume = currentVolume > 0 ? currentVolume : 100;
                 mMediaPlayer.setVolume(0);
             } else {
-                mMediaPlayer.setVolume(this.preVolume);
+                mMediaPlayer.setVolume(this.preVolume > 0 ? this.preVolume : 100);
             }
         }
     }


### PR DESCRIPTION
When VlcPlayer is initialized with muted=true, getVolume() returns 0,
causing preVolume to be saved as 0. This results in the player remaining
silent after unmuting via setState.

Fix: store a default volume of 100 when current volume is 0 before muting,
and use the same fallback when restoring volume on unmute.