### PR TITLE
fix(ios): set AVAudioSession category before playback to prevent audi…

### DIFF
--- a/ios/RCTVLCPlayer/RCTVLCPlayer.m
+++ b/ios/RCTVLCPlayer/RCTVLCPlayer.m
@@ -122,10 +122,13 @@ static NSString *const playbackRate = @"rate";
     self.dialogProvider.customRenderer = self;
     _player.media = [VLCMedia mediaWithURL:uri];
 
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
+                                 withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                                       error:nil];
+    [[AVAudioSession sharedInstance] setActive:YES error:nil];
+    
     if (_autoplay)
         [_player play];
-    
-    [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
 }
 
 - (void)setAutoplay:(BOOL)autoplay


### PR DESCRIPTION
Set AVAudioSessionCategoryPlayback with MixWithOthers option before player
starts, replacing the incorrect setActive:NO call which was deactivating
the audio session and causing conflicts with other audio sources.